### PR TITLE
Switch download to support proxies 

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "tar": "^6.1.0"
   },
   "devDependencies": {
+    "axios": "^1.4.0",
     "chai": "^4.3.6",
     "cli-color": "^2.0.2",
     "fs-extra": "^10.1.0",


### PR DESCRIPTION
The built-in `https` library does not support reading the standard `https_proxy` or `http_proxy` environment variables. This prevents the download from working in environments that require the use of a proxy. This change here simply switches to use the `axios` http client which supports those environment variables.