### PR TITLE
deps: fetch build artefacts using a proxy where necessary

### DIFF
--- a/deps/download.js
+++ b/deps/download.js
@@ -41,9 +41,6 @@ function download() {
   if (process.env.HTTPS_PROXY != undefined) {
     options.agent = new HttpsProxyAgent(process.env.HTTPS_PROXY);
   }
-  if (process.env.https_proxy != undefined) {
-    options.agent = new HttpsProxyAgent(process.env.https_proxy);
-  }
 
   https.get(URL, options, async (res) => {
     const out = fs.createWriteStream(tmpFile);

--- a/deps/download.js
+++ b/deps/download.js
@@ -1,4 +1,5 @@
 const https = require('https');
+const { HttpsProxyAgent } = require('https-proxy-agent');
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
@@ -35,7 +36,16 @@ async function main() {
 
 function download() {
   console.log(`downloading ${URL}`);
-  https.get(URL, async (res) => {
+
+  let options = {};
+  if (process.env.HTTPS_PROXY != undefined) {
+    options.agent = new HttpsProxyAgent(process.env.HTTPS_PROXY);
+  }
+  if (process.env.https_proxy != undefined) {
+    options.agent = new HttpsProxyAgent(process.env.https_proxy);
+  }
+
+  https.get(URL, options, async (res) => {
     const out = fs.createWriteStream(tmpFile);
 
     const hash = crypto.createHash('sha256');

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "bindings": "^1.5.0",
-    "https-proxy-agent": "^7.0.2",
+    "https-proxy-agent": "7.0.1",
     "tar": "^6.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   ],
   "dependencies": {
     "bindings": "^1.5.0",
+    "https-proxy-agent": "^7.0.2",
     "tar": "^6.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I've been struggling to build Signal from source where the build machine is behind a proxy.

This change will have no effect during build unless the `HTTPS_PROXY` variable is set, in which case it establishes an agent that will ensure the `https.get` calls use the proxy correctly.

I'm open to suggestions on a different approach if the addition of another dependency is too undesirable.